### PR TITLE
fix ParsedBody.asJson() issue with guard case.

### DIFF
--- a/Sources/TodoList/Controllers/App.swift
+++ b/Sources/TodoList/Controllers/App.swift
@@ -123,7 +123,7 @@ func setupRoutes(router: Router, todos: TodoCollection) {
             return
         }
 
-        guard let json = body.asJson() else {
+        guard case let .Json(json) = body else {
             response.status(HttpStatusCode.BAD_REQUEST)
             Log.error("Body is invalid JSON")
             return
@@ -165,7 +165,7 @@ func setupRoutes(router: Router, todos: TodoCollection) {
             return
         }
 
-        guard let json = body.asJson() else {
+        guard case let .Json(json) = body else {
             response.status(HttpStatusCode.BAD_REQUEST)
             Log.error("Body is invalid JSON")
             return
@@ -205,7 +205,7 @@ func setupRoutes(router: Router, todos: TodoCollection) {
             return
         }
 
-        guard let json = body.asJson() else {
+        guard case let .Json(json) = body else {
             response.status(HttpStatusCode.BAD_REQUEST)
             Log.error("Body is invalid JSON")
             return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ParsedBody has no `asJson()` method. So use `guard case` instead of `guard asJson()`.
```guard let json = body.asJson()``` -> ```guard case let .Json(json) = body```

## Motivation and Context
This fix a compile issue.

## How Has This Been Tested?
Test with 2015-04-25 snapshot of Swift.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

ParsedBody has no asJson method. So use guard case instead.
```guard let json = body.asJson()``` -> ```guard case let .Json(json) = body```