### PR TITLE
fix updates resetting values

### DIFF
--- a/Sources/TodoList/Controllers/App.swift
+++ b/Sources/TodoList/Controllers/App.swift
@@ -171,9 +171,9 @@ func setupRoutes(router: Router, todos: TodoCollection) {
             return
         }
 
-        let title = json["title"].stringValue
-        let order = json["order"].intValue
-        let completed = json["completed"].boolValue
+        let title = json["title"].string
+        let order = json["order"].int
+        let completed = json["completed"].bool
 
         todos.update(id: id, title: title, order: order, completed: completed) {
 
@@ -211,9 +211,9 @@ func setupRoutes(router: Router, todos: TodoCollection) {
             return
         }
 
-        let title = json["title"].stringValue
-        let order = json["order"].intValue
-        let completed = json["completed"].boolValue
+        let title = json["title"].string
+        let order = json["order"].int
+        let completed = json["completed"].bool
 
         todos.update(id: id, title: title, order: order, completed: completed) {
 


### PR DESCRIPTION
## Description
When updating, optionals should be preserved when parsing json body

## Motivation and Context
Fixes bug where any missing value in json body of an update will reset the todo item.
E.g. completing a todo from Todo-Frontend would clear it's title set it's order to 0.  

## How Has This Been Tested?
Clicktested vis Todo-Frontend
On MacOSX with swift-DEVELOPMENT-SNAPSHOT-2016-05-03-a

## Checklist:
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
